### PR TITLE
Fix view model injection for initial page

### DIFF
--- a/MauiAppBrownianMotion/MauiProgram.cs
+++ b/MauiAppBrownianMotion/MauiProgram.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.LifecycleEvents;
 using Syncfusion.Maui.Toolkit.Hosting;
+using MauiAppBrownianMotion.Utilities;
 
 #if WINDOWS
 using Microsoft.UI;
@@ -32,7 +33,10 @@ namespace MauiAppBrownianMotion
             builder.Services.AddSingleton<ModalErrorHandler>();
             builder.Services.AddSingleton<INavigationService, NavigationService>();
 
-            return builder.Build();
+            var app = builder.Build();
+            ServiceHelper.Initialize(app.Services);
+
+            return app;
         }
     }
 }

--- a/MauiAppBrownianMotion/Utilities/ServiceHelper.cs
+++ b/MauiAppBrownianMotion/Utilities/ServiceHelper.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace MauiAppBrownianMotion.Utilities
+{
+    /// <summary>
+    /// Provides access to the application's service provider before the MAUI handler pipeline is available.
+    /// </summary>
+    public static class ServiceHelper
+    {
+        /// <summary>
+        /// Gets the application's root service provider.
+        /// </summary>
+        public static IServiceProvider? Services { get; private set; }
+
+        /// <summary>
+        /// Initializes the helper with the application's root service provider.
+        /// </summary>
+        /// <param name="serviceProvider">The application's service provider.</param>
+        public static void Initialize(IServiceProvider serviceProvider)
+        {
+            Services = serviceProvider;
+        }
+    }
+}

--- a/MauiAppBrownianMotion/Views/Base/IMauiView.cs
+++ b/MauiAppBrownianMotion/Views/Base/IMauiView.cs
@@ -48,7 +48,7 @@ namespace MauiAppBrownianMotion.Views.Base
         /// <param name="view">View implementing <see cref="IMauiView"/>.</param>
         public static void InjectViewModel(this IMauiView view)
         {
-            var services = Application.Current?.Handler?.MauiContext?.Services;
+            var services = Application.Current?.Handler?.MauiContext?.Services ?? ServiceHelper.Services;
             if (services is null)
                 return;
 


### PR DESCRIPTION
## Summary
- ensure view model injection can resolve services before the MAUI handler pipeline is available
- cache the root service provider during app startup to support early view creation

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7ce8c0444832ead61270c92f8a3fb